### PR TITLE
Avoid rmarkdown halt for pdf output

### DIFF
--- a/source/rapport/index.Rmd
+++ b/source/rapport/index.Rmd
@@ -5,6 +5,7 @@ date: "`r Sys.Date()`"
 site: bookdown::bookdown_site
 bibliography: INBOmd.bib
 header-includes: \usepackage{lipsum}
+always_allow_html: yes
 output:
   bookdown::pdf_book:
     base_format: INBOmd::inbo_rapport_2015


### PR DESCRIPTION
Always allow HTML-specific content, also when generating PDF output. Before, rmarkdown complained and halted.