### PR TITLE
Security: GitHub Actions pinnen op volledige commit-SHA

### DIFF
--- a/.github/workflows/check_project.yml
+++ b/.github/workflows/check_project.yml
@@ -19,4 +19,4 @@ jobs:
 
     steps:
       - name: "Check project with checklist"
-        uses: inbo/actions/check_project@a29089fc9a2ea38b9d9bd62c0d1db3b448b224c8 # composite
+        uses: inbo/actions/check_project@composite

--- a/.github/workflows/check_project.yml
+++ b/.github/workflows/check_project.yml
@@ -19,4 +19,4 @@ jobs:
 
     steps:
       - name: "Check project with checklist"
-        uses: inbo/actions/check_project@composite
+        uses: inbo/actions/check_project@a29089fc9a2ea38b9d9bd62c0d1db3b448b224c8 # composite

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -13,6 +13,6 @@ jobs:
     name: "test Rmd"
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
-      - uses: inbo/actions/render_inbomd@55098124f283c4f9b9402d43ec4a9382ee05c105 # devel
+      - uses: inbo/actions/render_inbomd@devel
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/example.yml
+++ b/.github/workflows/example.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: "test Rmd"
     steps:
-      - uses: actions/checkout@v3
-      - uses: inbo/actions/render_inbomd@devel
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: inbo/actions/render_inbomd@55098124f283c4f9b9402d43ec4a9382ee05c105 # devel
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
_Onderdeel van een INBO-brede security-hardening: SHA-pinning van GitHub Actions. Aanbevolen door o.a. [GitHub Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)._